### PR TITLE
copytruncate support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # May, 2013
 
 * Recognize deletions/renames when using polling file watcher (PR #1)
+* Detect file truncation
+* Fix potential race condition when reopening the file (issue 5)
 
 # Feb, 2013
 

--- a/tail.go
+++ b/tail.go
@@ -13,8 +13,8 @@ import (
 )
 
 type Line struct {
-	Text     string
-	Time     time.Time
+	Text string
+	Time time.Time
 }
 
 // Tail configuration
@@ -156,7 +156,7 @@ func (tail *Tail) tailFileSync() {
 					for _, line := range partitionString(string(line), tail.MaxLineSize) {
 						tail.Lines <- &Line{line, now}
 					}
-				}else{
+				} else {
 					tail.Lines <- &Line{string(line), now}
 				}
 			}
@@ -186,7 +186,6 @@ func (tail *Tail) tailFileSync() {
 					if !ok {
 						changes = nil // XXX: how to kill changes' goroutine?
 
-						log.Println("Changes channel is closed.")
 						// File got deleted/renamed/truncated.
 						if tail.ReOpen {
 							// TODO: no logging in a library?
@@ -199,7 +198,7 @@ func (tail *Tail) tailFileSync() {
 							}
 							log.Printf("Successfully reopened %s", tail.Filename)
 							tail.reader = bufio.NewReader(tail.file)
-							
+
 							continue
 						} else {
 							log.Printf("Finishing because file has been moved/deleted: %s", tail.Filename)
@@ -208,7 +207,6 @@ func (tail *Tail) tailFileSync() {
 						}
 					}
 				case <-tail.Dying():
-					log.Println("Dying..")
 					tail.close()
 					return
 				}
@@ -231,7 +229,7 @@ func partitionString(s string, chunkSize int) []string {
 		panic("invalid chunkSize")
 	}
 	length := len(s)
-	chunks := 1 + length/chunkSize 
+	chunks := 1 + length/chunkSize
 	start := 0
 	end := chunkSize
 	parts := make([]string, 0, chunks)

--- a/tail_test.go
+++ b/tail_test.go
@@ -85,7 +85,7 @@ func _TestReOpen(_t *testing.T, poll bool) {
 	var name string
 	if poll {
 		name = "reopen-polling"
-	}else {
+	} else {
 		name = "reopen-inotify"
 	}
 	t := NewTailTest(name, _t)
@@ -93,7 +93,7 @@ func _TestReOpen(_t *testing.T, poll bool) {
 	tail := t.StartTail(
 		"test.txt",
 		Config{Follow: true, ReOpen: true, Poll: poll, Location: -1})
-	
+
 	go t.VerifyTailOutput(tail, []string{"hello", "world", "more", "data", "endofworld"})
 
 	// deletion must trigger reopen
@@ -138,12 +138,11 @@ func TestReOpenPolling(_t *testing.T) {
 	_TestReOpen(_t, true)
 }
 
-
 func _TestReSeek(_t *testing.T, poll bool) {
 	var name string
 	if poll {
 		name = "reseek-polling"
-	}else {
+	} else {
 		name = "reseek-inotify"
 	}
 	t := NewTailTest(name, _t)
@@ -151,7 +150,7 @@ func _TestReSeek(_t *testing.T, poll bool) {
 	tail := t.StartTail(
 		"test.txt",
 		Config{Follow: true, ReOpen: true, Poll: poll, Location: -1})
-	
+
 	go t.VerifyTailOutput(tail, []string{
 		"a really long string goes here", "hello", "world", "h311o", "w0r1d", "endofworld"})
 
@@ -176,7 +175,7 @@ func _TestReSeek(_t *testing.T, poll bool) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 
-	println("Stopping...")
+	println("Stopping (RESEEK)...")
 	tail.Stop()
 }
 
@@ -190,7 +189,6 @@ func TestReSeekInotify(_t *testing.T) {
 func TestReSeekPolling(_t *testing.T) {
 	_TestReSeek(_t, true)
 }
-
 
 // Test library
 
@@ -275,7 +273,7 @@ func (t TailTest) VerifyTailOutput(tail *Tail, lines []string) {
 			err := tail.Wait()
 			if err != nil {
 				t.Fatal("tail ended early with error: %v", err)
-			}else{
+			} else {
 				t.Fatalf("tail ended early; expecting more: %v", lines[idx:])
 			}
 		}


### PR DESCRIPTION
truncation detection for both inotify and polling file watchers along with test cases, plus a fix for issue #5.
