### PR TITLE
Fixed bug that stop method can't be done when the file isn't exists

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -108,7 +108,7 @@ func (tail *Tail) Tell() (offset int64, err error) {
 
 // Stop stops the tailing activity.
 func (tail *Tail) Stop() error {
-	tail.Kill(nil)
+	tail.Done()
 	return tail.Wait()
 }
 
@@ -147,7 +147,6 @@ func (tail *Tail) readLine() ([]byte, error) {
 }
 
 func (tail *Tail) tailFileSync() {
-	defer tail.Done()
 	defer tail.close()
 
 	if !tail.MustExist {

--- a/tail_test.go
+++ b/tail_test.go
@@ -33,7 +33,7 @@ func TestMustExist(t *testing.T) {
 		t.Error("MustExist:false is violated")
 	}
 	tail.Stop()
-	_, err = TailFile("README.md", Config{Follow: true, MustExist: true})
+	tail, err = TailFile("README.md", Config{Follow: true, MustExist: true})
 	if err != nil {
 		t.Error("MustExist:true on an existing file is violated")
 	}
@@ -333,6 +333,16 @@ func (t TailTest) StartTail(name string, config Config) *Tail {
 		t.Fatal(err)
 	}
 	return tail
+}
+
+func TestStop(t *testing.T) {
+	tail, err := TailFile("/no/such/file", Config{Follow: true, MustExist: false})
+	if err != nil {
+		t.Error("MustExist:false is violated")
+	}
+	if tail.Stop() != nil {
+		t.Error("Should be stoped successfully")
+	}
 }
 
 func (t TailTest) VerifyTailOutput(tail *Tail, lines []string) {


### PR DESCRIPTION
Just like the case of the follow case:

```
func TestStop(t *testing.T) {
    tail, err := TailFile("/no/such/file", Config{Follow: true, MustExist: false})
    if err != nil {
        t.Error("MustExist:false is violated")
    }
    if tail.Stop() != nil {
        t.Error("Should be stoped successfully")
    }
}
```

In this case, `(tail *Tail) tailFileSync()` always call `(tail *Tail) reopen()`until the log file appear.
When calling `(tail *Tail) Stop()`, the `dead` channel in  [`(t *Tomb) Wait()`](http://bazaar.launchpad.net/~niemeyer/tomb/trunk/view/head:/tomb.go#L110)  waitting for a value arrived or closed, but nothing will happen. So, the `(tail *Tail) Stop()` method always wait, it never quit untill the  log file appear.
But sometimes, I just want to quit and needn't to wait the log file appear, so I think that we can call the `
Done()` method instead of the `Kill(nil)` method in the `Stop()` method.
