### PR TITLE
fix race/panic on modify+delete

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -97,6 +97,10 @@ func (fw *InotifyFileWatcher) ChangeEvents(t tomb.Tomb, fi os.FileInfo) *FileCha
 			case evt.IsModify():
 				fi, err := os.Stat(fw.Filename)
 				if err != nil {
+					if os.IsNotExist(err) {
+						changes.NotifyDeleted()
+						return
+					}
 					// XXX: no panic here
 					panic(err)
 				}


### PR DESCRIPTION
This fixes a race condition when a file is modified and unlinked in the OS before the inotify IsModify event has a chance to call os.Stat.
