### PR TITLE
Add StopAtEOF to stop tailing when the end of the file is reached

### DIFF
--- a/tail_test.go
+++ b/tail_test.go
@@ -54,6 +54,25 @@ func TestStop(t *testing.T) {
 	Cleanup()
 }
 
+func TestStopAtEOF(_t *testing.T) {
+	t := NewTailTest("maxlinesize", _t)
+	t.CreateFile("test.txt", "hello\nthere\nworld\n")
+	tail := t.StartTail("test.txt", Config{Follow: true, Location: nil})
+
+	// read "hello"
+	<-tail.Lines
+
+	done := make(chan struct{})
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		t.VerifyTailOutput(tail, []string{"there", "world"})
+		close(done)
+	}()
+	tail.StopAtEOF()
+	<-done
+	Cleanup()
+}
+
 func TestMaxLineSize(_t *testing.T) {
 	t := NewTailTest("maxlinesize", _t)
 	t.CreateFile("test.txt", "hello\nworld\nfin\nhe")

--- a/watch/filechanges.go
+++ b/watch/filechanges.go
@@ -23,12 +23,6 @@ func (fc *FileChanges) NotifyDeleted() {
 	sendOnlyIfEmpty(fc.Deleted)
 }
 
-func (fc *FileChanges) Close() {
-	close(fc.Modified)
-	close(fc.Truncated)
-	close(fc.Deleted)
-}
-
 // sendOnlyIfEmpty sends on a bool channel only if the channel has no
 // backlog to be read by other goroutines. This concurrency pattern
 // can be used to notify other goroutines if and only if they are

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -77,7 +77,6 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 
 	go func() {
 		defer inotifyTracker.CloseWatcher(w)
-		defer changes.Close()
 
 		for {
 			prevSize := fw.Size

--- a/watch/polling.go
+++ b/watch/polling.go
@@ -49,8 +49,6 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, origFi os.FileInfo) *Fi
 	fw.Size = origFi.Size()
 
 	go func() {
-		defer changes.Close()
-
 		var retry int = 0
 
 		prevSize := fw.Size


### PR DESCRIPTION
This is useful when we know that the writer has stopped, and want to ensure that we read all lines before stopping.