### PR TITLE
Support tailing from a seekable reader

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -119,9 +119,7 @@ func TailReader(reader io.ReadCloser, config Config) (*Tail, error) {
 	if config.ReOpen || config.MustExist || config.Poll {
 		util.Fatal("Unsupported option")
 	}
-	switch reader.(type) {
-	case io.Seeker:
-	default:
+	if _, ok := reader.(io.Seeker); !ok {
 		util.Fatal("reader must implement io.Seeker")
 	}
 


### PR DESCRIPTION
This adds the possibility to use tail on a `io.ReadCloser` that's also a `io.Seeker`.  It mostly does nothing very interesting in that case, but is easier for consumers to deal with.