### PR TITLE
Single shared Watcher used to avoid inotify limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ go:
   - 1.4.2
 
 install:
-  - go get gopkg.in/fsnotify.v0
+  - go get gopkg.in/fsnotify.v1

--- a/tail.go
+++ b/tail.go
@@ -290,11 +290,11 @@ func (tail *Tail) tailFileSync() {
 // reopened if ReOpen is true. Truncated files are always reopened.
 func (tail *Tail) waitForChanges() error {
 	if tail.changes == nil {
-		st, err := tail.file.Stat()
+		pos, err := tail.file.Seek(0, os.SEEK_CUR)
 		if err != nil {
 			return err
 		}
-		tail.changes = tail.watcher.ChangeEvents(&tail.Tomb, st)
+		tail.changes = tail.watcher.ChangeEvents(&tail.Tomb, pos)
 	}
 
 	select {
@@ -340,7 +340,7 @@ func (tail *Tail) openReader() {
 }
 
 func (tail *Tail) seekEnd() error {
-	return tail.seekTo(SeekInfo{Offset: 0, Whence: 2})
+	return tail.seekTo(SeekInfo{Offset: 0, Whence: os.SEEK_END})
 }
 
 func (tail *Tail) seekTo(pos SeekInfo) error {

--- a/tail.go
+++ b/tail.go
@@ -62,9 +62,8 @@ type Tail struct {
 	Lines    chan *Line
 	Config
 
-	file    *os.File
-	reader  *bufio.Reader
-	tracker *watch.InotifyTracker
+	file   *os.File
+	reader *bufio.Reader
 
 	watcher watch.FileWatcher
 	changes *watch.FileChanges
@@ -102,12 +101,7 @@ func TailFile(filename string, config Config) (*Tail, error) {
 	if t.Poll {
 		t.watcher = watch.NewPollingFileWatcher(filename)
 	} else {
-		t.tracker = watch.NewInotifyTracker()
-		w, err := t.tracker.NewWatcher()
-		if err != nil {
-			return nil, err
-		}
-		t.watcher = watch.NewInotifyFileWatcher(filename, w)
+		t.watcher = watch.NewInotifyFileWatcher(filename)
 	}
 
 	if t.MustExist {
@@ -390,7 +384,5 @@ func (tail *Tail) sendLine(line string) bool {
 // meant to be invoked from a process's exit handler. Linux kernel may not
 // automatically remove inotify watches after the process exits.
 func (tail *Tail) Cleanup() {
-	if tail.tracker != nil {
-		tail.tracker.CloseAll()
-	}
+	watch.Cleanup(tail.Filename)
 }

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -77,7 +77,7 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 		for {
 			prevSize := fw.Size
 
-			var evt *fsnotify.Event
+			var evt fsnotify.Event
 			var ok bool
 
 			select {

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v0"
+	"gopkg.in/fsnotify.v1"
 	"gopkg.in/tomb.v1"
 )
 
@@ -28,7 +28,7 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 	dirname := filepath.Dir(fw.Filename)
 
 	// Watch for new files to be created in the parent directory.
-	err := WatchFlags(dirname, fsnotify.FSN_CREATE)
+	err := Watch(dirname)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 		for {
 			prevSize := fw.Size
 
-			var evt *fsnotify.FileEvent
+			var evt *fsnotify.Event
 			var ok bool
 
 			select {
@@ -90,14 +90,14 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 			}
 
 			switch {
-			case evt.IsDelete():
+			case evt.Op&fsnotify.Remove == fsnotify.Remove:
 				fallthrough
 
-			case evt.IsRename():
+			case evt.Op&fsnotify.Rename == fsnotify.Rename:
 				changes.NotifyDeleted()
 				return
 
-			case evt.IsModify():
+			case evt.Op&fsnotify.Write == fsnotify.Write:
 				fi, err := os.Stat(fw.Filename)
 				if err != nil {
 					if os.IsNotExist(err) {

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -28,11 +28,11 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 	dirname := filepath.Dir(fw.Filename)
 
 	// Watch for new files to be created in the parent directory.
-	err := shared.WatchFlags(dirname, fsnotify.FSN_CREATE)
+	err := WatchFlags(dirname, fsnotify.FSN_CREATE)
 	if err != nil {
 		return err
 	}
-	defer shared.RemoveWatch(dirname)
+	defer RemoveWatch(dirname)
 
 	// Do a real check now as the file might have been created before
 	// calling `WatchFlags` above.
@@ -41,7 +41,7 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 		return err
 	}
 
-	events := shared.Events(fw.Filename)
+	events := Events(fw.Filename)
 
 	for {
 		select {
@@ -61,7 +61,7 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileChanges {
 	changes := NewFileChanges()
 
-	err := shared.Watch(fw.Filename)
+	err := Watch(fw.Filename)
 	if err != nil {
 		go changes.NotifyDeleted()
 	}
@@ -69,10 +69,10 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 	fw.Size = fi.Size()
 
 	go func() {
-		defer shared.RemoveWatch(fw.Filename)
+		defer RemoveWatch(fw.Filename)
 		defer changes.Close()
 
-		events := shared.Events(fw.Filename)
+		events := Events(fw.Filename)
 
 		for {
 			prevSize := fw.Size

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -58,7 +58,7 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 	panic("unreachable")
 }
 
-func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileChanges {
+func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) *FileChanges {
 	changes := NewFileChanges()
 
 	err := Watch(fw.Filename)
@@ -66,7 +66,7 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, fi os.FileInfo) *FileCh
 		go changes.NotifyDeleted()
 	}
 
-	fw.Size = fi.Size()
+	fw.Size = pos
 
 	go func() {
 		defer RemoveWatch(fw.Filename)

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/hpcloud/tail/util"
 
@@ -113,8 +114,12 @@ func (shared *InotifyTracker) run() {
 		case err, open := <-shared.watcher.Error:
 			if !open {
 				return
+			} else if err != nil {
+				sysErr, ok := err.(*os.SyscallError)
+				if !ok || sysErr.Err != syscall.EINTR {
+					logger.Printf("Error in Watcher Error channel: %s", err)
+				}
 			}
-			logger.Printf("Error in Watcher Errors channel: %s", err)
 
 		case <-shared.done:
 			return

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v0"
+	"gopkg.in/fsnotify.v1"
 )
 
 type InotifyTracker struct {
 	mux     sync.Mutex
 	watcher *fsnotify.Watcher
-	chans   map[string]chan *fsnotify.FileEvent
+	chans   map[string]chan *fsnotify.Event
 	done    map[string]chan bool
 	watch   chan *watchInfo
 	remove  chan string
@@ -25,7 +25,6 @@ type InotifyTracker struct {
 
 type watchInfo struct {
 	fname string
-	flags uint32
 }
 
 var (
@@ -37,7 +36,7 @@ var (
 	goRun = func() {
 		shared = &InotifyTracker{
 			mux:    sync.Mutex{},
-			chans:  make(map[string]chan *fsnotify.FileEvent),
+			chans:  make(map[string]chan *fsnotify.Event),
 			done:   make(map[string]chan bool),
 			watch:  make(chan *watchInfo),
 			remove: make(chan string),
@@ -49,21 +48,13 @@ var (
 	logger = log.New(os.Stderr, "", log.LstdFlags)
 )
 
-// WatchFlags signals the run goroutine to begin watching the input filename using
-// using all flags.
+// Watch signals the run goroutine to begin watching the input filename
 func Watch(fname string) error {
-	return WatchFlags(fname, fsnotify.FSN_ALL)
-}
-
-// WatchFlags signals the run goroutine to begin watching the input filename using
-// using the input flags.
-func WatchFlags(fname string, flags uint32) error {
 	// start running the shared InotifyTracker if not already running
 	once.Do(goRun)
 
 	shared.watch <- &watchInfo{
 		fname: fname,
-		flags: flags,
 	}
 	return <-shared.error
 }
@@ -87,7 +78,7 @@ func RemoveWatch(fname string) {
 // Events returns a channel to which FileEvents corresponding to the input filename
 // will be sent. This channel will be closed when removeWatch is called on this
 // filename.
-func Events(fname string) chan *fsnotify.FileEvent {
+func Events(fname string) chan *fsnotify.Event {
 	shared.mux.Lock()
 	defer shared.mux.Unlock()
 
@@ -101,15 +92,15 @@ func Cleanup(fname string) {
 
 // watchFlags calls fsnotify.WatchFlags for the input filename and flags, creating
 // a new Watcher if the previous Watcher was closed.
-func (shared *InotifyTracker) watchFlags(fname string, flags uint32) error {
+func (shared *InotifyTracker) addWatch(fname string) error {
 	shared.mux.Lock()
 	defer shared.mux.Unlock()
 
 	if shared.chans[fname] == nil {
-		shared.chans[fname] = make(chan *fsnotify.FileEvent)
+		shared.chans[fname] = make(chan *fsnotify.Event)
 		shared.done[fname] = make(chan bool)
 	}
-	return shared.watcher.WatchFlags(fname, flags)
+	return shared.watcher.Add(fname)
 }
 
 // removeWatch calls fsnotify.RemoveWatch for the input filename and closes the
@@ -119,7 +110,7 @@ func (shared *InotifyTracker) removeWatch(fname string) {
 	defer shared.mux.Unlock()
 
 	if ch := shared.chans[fname]; ch != nil {
-		shared.watcher.RemoveWatch(fname)
+		shared.watcher.Remove(fname)
 
 		delete(shared.chans, fname)
 		close(ch)
@@ -127,7 +118,7 @@ func (shared *InotifyTracker) removeWatch(fname string) {
 }
 
 // sendEvent sends the input event to the appropriate Tail.
-func (shared *InotifyTracker) sendEvent(event *fsnotify.FileEvent) {
+func (shared *InotifyTracker) sendEvent(event *fsnotify.Event) {
 	shared.mux.Lock()
 	ch := shared.chans[event.Name]
 	done := shared.done[event.Name]
@@ -153,18 +144,18 @@ func (shared *InotifyTracker) run() {
 	for {
 		select {
 		case winfo := <-shared.watch:
-			shared.error <- shared.watchFlags(winfo.fname, winfo.flags)
+			shared.error <- shared.addWatch(winfo.fname)
 
 		case fname := <-shared.remove:
 			shared.removeWatch(fname)
 
-		case event, open := <-shared.watcher.Event:
+		case event, open := <-shared.watcher.Events:
 			if !open {
 				return
 			}
-			shared.sendEvent(event)
+			shared.sendEvent(&event)
 
-		case err, open := <-shared.watcher.Error:
+		case err, open := <-shared.watcher.Errors:
 			if !open {
 				return
 			} else if err != nil {

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -16,7 +16,7 @@ import (
 type InotifyTracker struct {
 	mux     sync.Mutex
 	watcher *fsnotify.Watcher
-	chans   map[string]chan *fsnotify.Event
+	chans   map[string]chan fsnotify.Event
 	done    map[string]chan bool
 	watch   chan *watchInfo
 	remove  chan string
@@ -36,7 +36,7 @@ var (
 	goRun = func() {
 		shared = &InotifyTracker{
 			mux:    sync.Mutex{},
-			chans:  make(map[string]chan *fsnotify.Event),
+			chans:  make(map[string]chan fsnotify.Event),
 			done:   make(map[string]chan bool),
 			watch:  make(chan *watchInfo),
 			remove: make(chan string),
@@ -78,7 +78,7 @@ func RemoveWatch(fname string) {
 // Events returns a channel to which FileEvents corresponding to the input filename
 // will be sent. This channel will be closed when removeWatch is called on this
 // filename.
-func Events(fname string) chan *fsnotify.Event {
+func Events(fname string) chan fsnotify.Event {
 	shared.mux.Lock()
 	defer shared.mux.Unlock()
 
@@ -97,7 +97,7 @@ func (shared *InotifyTracker) addWatch(fname string) error {
 	defer shared.mux.Unlock()
 
 	if shared.chans[fname] == nil {
-		shared.chans[fname] = make(chan *fsnotify.Event)
+		shared.chans[fname] = make(chan fsnotify.Event)
 		shared.done[fname] = make(chan bool)
 	}
 	return shared.watcher.Add(fname)
@@ -118,7 +118,7 @@ func (shared *InotifyTracker) removeWatch(fname string) {
 }
 
 // sendEvent sends the input event to the appropriate Tail.
-func (shared *InotifyTracker) sendEvent(event *fsnotify.Event) {
+func (shared *InotifyTracker) sendEvent(event fsnotify.Event) {
 	shared.mux.Lock()
 	ch := shared.chans[event.Name]
 	done := shared.done[event.Name]
@@ -153,7 +153,7 @@ func (shared *InotifyTracker) run() {
 			if !open {
 				return
 			}
-			shared.sendEvent(&event)
+			shared.sendEvent(event)
 
 		case err, open := <-shared.watcher.Errors:
 			if !open {

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -3,49 +3,121 @@
 package watch
 
 import (
-	"gopkg.in/fsnotify.v0"
 	"log"
+	"os"
 	"sync"
+
+	"github.com/hpcloud/tail/util"
+
+	"gopkg.in/fsnotify.v0"
 )
 
 type InotifyTracker struct {
-	mux      sync.Mutex
-	watchers map[*fsnotify.Watcher]bool
+	mux     sync.Mutex
+	watcher *fsnotify.Watcher
+	chans   map[string]chan *fsnotify.FileEvent
+	done    chan struct{}
 }
 
-func NewInotifyTracker() *InotifyTracker {
-	t := new(InotifyTracker)
-	t.watchers = make(map[*fsnotify.Watcher]bool)
-	return t
-}
-
-func (t *InotifyTracker) NewWatcher() (*fsnotify.Watcher, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-	w, err := fsnotify.NewWatcher()
-	if err == nil {
-		t.watchers[w] = true
+var (
+	shared = &InotifyTracker{
+		mux:   sync.Mutex{},
+		chans: make(map[string]chan *fsnotify.FileEvent),
 	}
-	return w, err
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+)
+
+// Watch calls fsnotify.Watch for the input filename, creating a new Watcher if the
+// previous Watcher was closed.
+func (shared *InotifyTracker) Watch(filename string) error {
+	return shared.WatchFlags(filename, fsnotify.FSN_ALL)
 }
 
-func (t *InotifyTracker) CloseWatcher(w *fsnotify.Watcher) (err error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-	if _, ok := t.watchers[w]; ok {
-		err = w.Close()
-		delete(t.watchers, w)
-	}
-	return
-}
+// WatchFlags calls fsnotify.WatchFlags for the input filename and flags, creating
+// a new Watcher if the previous Watcher was closed.
+func (shared *InotifyTracker) WatchFlags(filename string, flags uint32) error {
+	shared.mux.Lock()
+	defer shared.mux.Unlock()
 
-func (t *InotifyTracker) CloseAll() {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-	for w, _ := range t.watchers {
-		if err := w.Close(); err != nil {
-			log.Printf("Error closing watcher: %v", err)
+	// Start up shared struct if necessary
+	if len(shared.chans) == 0 {
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			util.Fatal("Error creating Watcher")
 		}
-		delete(t.watchers, w)
+		shared.watcher = watcher
+		shared.done = make(chan struct{})
+		go shared.run()
+	}
+
+	// Create a channel to which FileEvents for the input filename will be sent
+	ch := shared.chans[filename]
+	if ch == nil {
+		shared.chans[filename] = make(chan *fsnotify.FileEvent)
+	}
+	return shared.watcher.WatchFlags(filename, flags)
+}
+
+// RemoveWatch calls fsnotify.RemoveWatch for the input filename and closes the
+// corresponding events channel.
+func (shared *InotifyTracker) RemoveWatch(filename string) {
+	shared.mux.Lock()
+	defer shared.mux.Unlock()
+
+	_, found := shared.chans[filename]
+	if !found {
+		return
+	}
+
+	shared.watcher.RemoveWatch(filename)
+	delete(shared.chans, filename)
+
+	// If this is the last target to be removed, close the shared Watcher
+	if len(shared.chans) == 0 {
+		shared.watcher.Close()
+		close(shared.done)
+	}
+}
+
+// Events returns a channel to which FileEvents corresponding to the input filename
+// will be sent. This channel will be closed when removeWatch is called on this
+// filename.
+func (shared *InotifyTracker) Events(filename string) <-chan *fsnotify.FileEvent {
+	shared.mux.Lock()
+	defer shared.mux.Unlock()
+
+	return shared.chans[filename]
+}
+
+// Cleanup removes the watch for the input filename and closes the shared Watcher
+// if there are no more targets.
+func Cleanup(filename string) {
+	shared.RemoveWatch(filename)
+}
+
+// run starts the goroutine in which the shared struct reads events from its
+// Watcher's Event channel and sends the events to the appropriate Tail.
+func (shared *InotifyTracker) run() {
+	for {
+		select {
+		case event, open := <-shared.watcher.Event:
+			if !open {
+				return
+			}
+			// send the FileEvent to the appropriate Tail's channel
+			ch := shared.chans[event.Name]
+			if ch != nil {
+				ch <- event
+			}
+
+		case err, open := <-shared.watcher.Error:
+			if !open {
+				return
+			}
+			logger.Printf("Error in Watcher Errors channel: %s", err)
+
+		case <-shared.done:
+			return
+		}
 	}
 }

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -2,10 +2,7 @@
 
 package watch
 
-import (
-	"gopkg.in/tomb.v1"
-	"os"
-)
+import "gopkg.in/tomb.v1"
 
 // FileWatcher monitors file-level events.
 type FileWatcher interface {
@@ -16,5 +13,7 @@ type FileWatcher interface {
 	// deletion, renames or truncations. Returned FileChanges group of
 	// channels will be closed, thus become unusable, after a deletion
 	// or truncation event.
-	ChangeEvents(*tomb.Tomb, os.FileInfo) *FileChanges
+	// In order to properly report truncations, ChangeEvents requires
+	// the caller to pass their current offset in the file.
+	ChangeEvents(*tomb.Tomb, int64) *FileChanges
 }


### PR DESCRIPTION
When we were using this tail library, we found that the system limit on inotify watches would become an issue when we we try to tail many files at once (if many Tail objects are open simultaneously). To circumvent this, we changed the InotifyTracker struct to contain a Watcher that is shared by all Tail objects that are created. 