### PR TITLE
Reopen deleted files properly, and fix BlockUntilExists for relative paths

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -46,7 +46,7 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 		case evt, ok := <-fw.w.Event:
 			if !ok {
 				return fmt.Errorf("inotify watcher has been closed")
-			} else if evt.Name == fw.Filename {
+			} else if filepath.Base(evt.Name) == filepath.Base(fw.Filename) {
 				return nil
 			}
 		case <-t.Dying():


### PR DESCRIPTION
This fixes two bugs:

1. Issue #57 - the inotify watcher wouldn't notice when a file was deleted because the inotify event actually comes on the directory and it only watches the file itself.
2. Watching a file in the current directory with a relative path that doesn't exist yet wouldn't work because the inotify events are for "./foo" not "foo".  I found https://github.com/hpcloud/tail/pull/48 afterwards which also fixes this bug.

Also many of the tests in tail_test.go weren't actually working properly because the test function wasn't waiting for the goroutine to exit.  One of the tests was actually exercising the first bug, but wasn't failing for this reason.