### PR TITLE
fix block until exists function

### DIFF
--- a/tail_test.go
+++ b/tail_test.go
@@ -155,7 +155,7 @@ func TestLocationEnd(_t *testing.T) {
 
 func TestLocationMiddle(_t *testing.T) {
 	// Test reading from middle.
-	t := NewTailTest("location-end", _t)
+	t := NewTailTest("location-middle", _t)
 	t.CreateFile("test.txt", "hello\nworld\n")
 	tail := t.StartTail("test.txt", Config{Follow: true, Location: &SeekInfo{-6, os.SEEK_END}})
 	go t.VerifyTailOutput(tail, []string{"world", "more", "data"})

--- a/tail_test.go
+++ b/tail_test.go
@@ -331,6 +331,28 @@ func TestTell(_t *testing.T) {
 	tail.Cleanup()
 }
 
+func TestBlockUntilExists(_t *testing.T) {
+	t := NewTailTest("block-until-file-exists", _t)
+	config := Config{
+		Follow: true,
+	}
+	tail := t.StartTail("test.txt", config)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		t.CreateFile("test.txt", "hello world\n")
+	}()
+	for l := range tail.Lines {
+		if l.Text != "hello world" {
+			t.Fatalf("mismatch; expected hello world, but got %s",
+				l.Text)
+		}
+		break
+	}
+	t.RemoveFile("test.txt")
+	tail.Stop()
+	tail.Cleanup()
+}
+
 // Test library
 
 type TailTest struct {

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -41,14 +41,14 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 		return err
 	}
 
-	events := Events(fw.Filename)
+	events := Events(dirname)
 
 	for {
 		select {
 		case evt, ok := <-events:
 			if !ok {
 				return fmt.Errorf("inotify watcher has been closed")
-			} else if evt.Name == fw.Filename {
+			} else if filepath.Clean(evt.Name) == fw.Filename {
 				return nil
 			}
 		case <-t.Dying():

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -5,6 +5,7 @@ package watch
 import (
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -119,9 +120,14 @@ func (shared *InotifyTracker) removeWatch(fname string) {
 
 // sendEvent sends the input event to the appropriate Tail.
 func (shared *InotifyTracker) sendEvent(event fsnotify.Event) {
+	name := event.Name
+	if event.Op == fsnotify.Create {
+		name = filepath.Dir(name)
+	}
+
 	shared.mux.Lock()
-	ch := shared.chans[event.Name]
-	done := shared.done[event.Name]
+	ch := shared.chans[name]
+	done := shared.done[name]
 	shared.mux.Unlock()
 
 	if ch != nil && done != nil {


### PR DESCRIPTION
When we run the flow program, then execute `echo 1 > not_exist` in shell, the result is not we want to.

```
package main

import (
	"fmt"

	"github.com/hpcloud/tail"
)

func main() {
	t, err := tail.TailFile("not_exists", tail.Config{
		Follow:    true,
		MustExist: false,
	})

	if err != nil {
		fmt.Printf("err=%+v\n", err)
		return
	}

	for {
		select {
		case line := <-t.Lines:
			fmt.Printf("line=%s\n", line)
		}
	}
}
```