### PR TITLE
fix reader nil pointer

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -142,11 +142,17 @@ func (tail *Tail) Tell() (offset int64, err error) {
 		return
 	}
 	offset, err = tail.file.Seek(0, os.SEEK_CUR)
-	if err == nil {
-		tail.lk.Lock()
-		offset -= int64(tail.reader.Buffered())
-		tail.lk.Unlock()
+	if err != nil {
+		return
 	}
+
+	tail.lk.Lock()
+	defer tail.lk.Unlock()
+	if tail.reader == nil {
+		return
+	}
+
+	offset -= int64(tail.reader.Buffered())
 	return
 }
 


### PR DESCRIPTION
The Tail [read the reader](https://github.com/hpcloud/tail/blob/master/tail.go#L147) goroutine is different of the [reader create](https://github.com/hpcloud/tail/blob/master/tail.go#L131) goroutine, it is communicate by sharing memory, the reader may be nil when the `Tell` called.

ps: our program hit this bug.