### PR TITLE
Fix deadlock when watching files with inotify

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -158,10 +158,10 @@ func (tail *Tail) Stop() error {
 
 func (tail *Tail) close() {
 	close(tail.Lines)
-	tail.colseFile()
+	tail.closeFile()
 }
 
-func (tail *Tail) colseFile() {
+func (tail *Tail) closeFile() {
 	if tail.file != nil {
 		tail.file.Close()
 		tail.file = nil
@@ -169,7 +169,7 @@ func (tail *Tail) colseFile() {
 }
 
 func (tail *Tail) reopen() error {
-	tail.colseFile()
+	tail.closeFile()
 	for {
 		var err error
 		tail.file, err = OpenFile(tail.Filename)

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -133,7 +133,7 @@ func remove(winfo *watchInfo) {
 // Events returns a channel to which FileEvents corresponding to the input filename
 // will be sent. This channel will be closed when removeWatch is called on this
 // filename.
-func Events(fname string) chan fsnotify.Event {
+func Events(fname string) <-chan fsnotify.Event {
 	shared.mux.Lock()
 	defer shared.mux.Unlock()
 


### PR DESCRIPTION
Calling `watcher.Remove()` from the `run()` goroutine is now problematic, because with the change made in fsnotify/fsnotify#73 `Remove()` can now take an arbitrary amount of time, which means we can deadlock if `run()` is waiting for fsnotify to acknowledge the removal and fsnotify is trying to send an unrelated `Event`.

So instead we now do part of the cleanup, including calling `watcher.Remove()`, synchronously, in the goroutine trying to unsubscribe.

This fixes #75.  Thanks to @aaronbee for the fix.