### PR TITLE
Fixes race in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default:	test
 
 test:	*.go
-	go test -v ./...
+	go test -v -race ./...
 
 fmt:
 	gofmt -w .

--- a/tail_test.go
+++ b/tail_test.go
@@ -25,6 +25,13 @@ func init() {
 	}
 }
 
+func TestMain(m *testing.M) {
+	// Use a smaller poll duration for faster test runs. Keep it below
+	// 100ms (which value is used as common delays for tests)
+	watch.POLL_DURATION = 5 * time.Millisecond
+	os.Exit(m.Run())
+}
+
 func TestMustExist(t *testing.T) {
 	tail, err := TailFile("/no/such/file", Config{Follow: true, MustExist: true})
 	if err == nil {
@@ -386,10 +393,6 @@ func NewTailTest(name string, t *testing.T) TailTest {
 	if err != nil {
 		tt.Fatal(err)
 	}
-
-	// Use a smaller poll duration for faster test runs. Keep it below
-	// 100ms (which value is used as common delays for tests)
-	watch.POLL_DURATION = 5 * time.Millisecond
 
 	return tt
 }


### PR DESCRIPTION
- Enabled race flag in the make file to alway run with -race locally
- Moved polling interval into TestMain to avoid race