### PR TITLE
inotify.go: Fix bug where inotify returns IN_ATTRIB against an open fd when deleted

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -95,6 +95,15 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			}
 
 			switch {
+			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
+			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
+				if _, err := os.Stat(fw.Filename); err != nil {
+					if ! os.IsNotExist(err) {
+						return
+					}
+				}
+				fallthrough
+
 			case evt.Op&fsnotify.Remove == fsnotify.Remove:
 				fallthrough
 


### PR DESCRIPTION
While investigating why deleting a log file, then recreating and writing to it, tail would not ReOpen the log file.

As a test:

```
echo foo > test.log
tail -f test.log &
inotifywait -m test.log &
rm test.log (at this point, inotify issues an IN_ATTRIB on an open fd)
echo bar > test.log  (tail does not reopen)
kill $(pidof tail)  (now inotify will issue an IN_DELETE_SELF as the fd is closed and the inode is able to be purged from the filesystem)
```

The patch I'm submitting tests for this case and fallsthrough into the fsnotify.Remove code, which appears to handle it correctly.

Please look it over and let me know if this was the correct way to fix the problem.

As an aside, I'm also using this patch: https://github.com/hpcloud/tail/pull/99  (Tailing stop bug fix)
