### PR TITLE
ratelimit: fix bucket collection eviction

### DIFF
--- a/ratelimiter/memory.go
+++ b/ratelimiter/memory.go
@@ -5,7 +5,10 @@ import (
 	"time"
 )
 
-const GC_SIZE int = 100
+const (
+	GC_SIZE   int           = 100
+	GC_PERIOD time.Duration = 60 * time.Second
+)
 
 type Memory struct {
 	store           map[string]LeakyBucket
@@ -44,11 +47,10 @@ func (m *Memory) GarbageCollect() {
 	now := time.Now()
 
 	// rate limit GC to once per minute
-	if now.Add(60*time.Second).Unix() > m.lastGCCollected.Unix() {
-
+	if now.Unix() >= m.lastGCCollected.Add(GC_PERIOD).Unix() {
 		for key, bucket := range m.store {
 			// if the bucket is drained, then GC
-			if bucket.DrainedAt().Unix() > now.Unix() {
+			if bucket.DrainedAt().Unix() < now.Unix() {
 				delete(m.store, key)
 			}
 		}


### PR DESCRIPTION
Two (all-too-easily) inverted checks are causing all ***undrained*** buckets to be evicted every on every bucket insert when there are more than 100 buckets.  Drained buckets are never evicted.

I was reading the code and noticed it, but now I don't see `ratelimiter.Memory` used anywhere.

Testing this isn't pretty but I can do it if you'd like.