### PR TITLE
Seek by line

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"math"
 
 	"github.com/hpcloud/tail/ratelimiter"
 	"github.com/hpcloud/tail/util"
@@ -221,6 +222,103 @@ func (tail *Tail) readLine() (string, error) {
 	line = strings.TrimRight(line, "\n")
 
 	return line, err
+}
+
+const BufferLength = 32 * 1024
+
+// seeks through file by line
+// 0 lines, 1 whence will return begining of current line
+// 1 lines, 1 whence will return begining of next line
+// 0 lines, 2 whence will return begining of last line
+// negative lines will move backwards in file
+func (tail *Tail) SeekLine(lines int64, whence int) (int64, error) {
+	BOF := errors.New("Begining of file")
+
+	// return error on bad whence
+	if whence < 0 || whence > 2 {
+		return tail.file.Seek(0, whence)
+	}
+
+	position, err := tail.file.Seek(0, whence)
+
+	buf := make([]byte, BufferLength)
+	bufLen := 0
+	lineSep := byte('\n')
+	seekBack := lines < 1
+	lines = int64(math.Abs(float64(lines)))
+	matchCount := int64(0)
+
+	// seekBack ignores first match
+	// allows 0 to go to begining of current line
+	if seekBack {
+		matchCount = -1
+	}
+
+	leftPosition := position
+	offset := int64(BufferLength * -1)
+
+	for b := 1; ; b++ {
+		if err != nil {
+			break
+		}
+
+		if seekBack {
+
+			// on seekBack 2nd buffer onward needs to seek
+			// past what was just read plus another buffer size
+			if b == 2 {
+				offset *= 2
+			}
+
+			// if next seekBack will pass beginning of file
+			// buffer is 0 to unread position
+			if position+int64(offset) <= 0 {
+				buf = make([]byte, leftPosition)
+				position, err = tail.file.Seek(0, io.SeekStart)
+				leftPosition = 0
+			} else {
+				position, err = tail.file.Seek(offset, io.SeekCurrent)
+				leftPosition = leftPosition - BufferLength
+			}
+		}
+		if err != nil {
+			break
+		}
+
+		bufLen, err = tail.file.Read(buf)
+		if err != nil {
+			break
+		} else if leftPosition == 0 {
+			err = BOF
+		}
+
+		for i := 0; i < bufLen; i++ {
+			iToCheck := i
+			if seekBack {
+				iToCheck = bufLen - i - 1
+			}
+			byteToCheck := buf[iToCheck]
+
+			if byteToCheck == lineSep {
+				matchCount++
+			}
+
+			if matchCount == lines {
+				if seekBack {
+					return tail.file.Seek(int64(i)*-1, io.SeekCurrent)
+				}
+				return tail.file.Seek(int64(bufLen*-1+i+1), io.SeekCurrent)
+			}
+		}
+	}
+
+	if err == io.EOF {
+		position, _ = tail.file.Seek(0, io.SeekEnd)
+	} else if err == BOF {
+		position, _ = tail.file.Seek(0, io.SeekStart)
+	}
+
+	return position, err
 }
 
 func (tail *Tail) tailFileSync() {

--- a/tail.go
+++ b/tail.go
@@ -318,11 +318,10 @@ func (tail *Tail) SeekLine(lines int64, whence int) (int64, error) {
 	}
 
 	if err == io.EOF {
-		position, _ = tail.file.Seek(0, io.SeekEnd)
+		position, err = tail.file.Seek(0, io.SeekEnd)
 	} else if err == BOF {
-		position, _ = tail.file.Seek(0, io.SeekStart)
+		position, err = tail.file.Seek(0, io.SeekStart)
 	}
-
 	return position, err
 }
 


### PR DESCRIPTION
This is a a rough draft for issue #83 seek by line. I am pretty new to Go (started learning 2 weeks ago) so there are probably a lot of issues with Go style. I also didn't try too hard to match project style on this draft. Any feedback will be in PR update.

No tests yet. I had some issues running existing tests kept getting error 
`./tail.go:201: cannot use &tail.Tomb (type *"gopkg.in/tomb.v1".Tomb) as type *"github.com/hpcloud/tail/vendor/gopkg.in/tomb.v1".Tomb in argument to tail.watcher.BlockUntilExists`

I won't have time to pick this up again for another week or two at which point I will figure how how to do Go testing. I just wanted to get this out there to get your feedback in the meantime.

tail.SeekLine(0,0) -> beginning of first line
tail.SeekLine(1,0) -> beginning of second line
tail.SeekLine(0,1) -> beginning of current line
tail.SeekLine(1,1) -> beginning of next line
tail.SeekLine(-1,1) -> beginning of previous line
tail.SeekLine(0,2) -> beginning of last line
tail.SeekLine(1,2) -> EOF