### PR TITLE
Issue 111: TestReSeekInotify failed

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -96,15 +96,6 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			}
 
 			switch {
-			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
-			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
-				if _, err := os.Stat(fw.Filename); err != nil {
-					if ! os.IsNotExist(err) {
-						return
-					}
-				}
-				fallthrough
-
 			case evt.Op&fsnotify.Remove == fsnotify.Remove:
 				fallthrough
 
@@ -112,6 +103,10 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 				RemoveWatch(fw.Filename)
 				changes.NotifyDeleted()
 				return
+
+			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
+			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
+				fallthrough
 
 			case evt.Op&fsnotify.Write == fsnotify.Write:
 				fi, err := os.Stat(fw.Filename)


### PR DESCRIPTION
if "case fsnotify.Chmod" logic before "case fsnotify.Rename"
always `return changes.NotifyDeleted()`

Test case pass:
macOs 10.11.6 + go 1.6.2
Centos 6.4 + go 1.8