### PR TITLE
Fixes file truncation on Mac.

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -96,12 +96,14 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			}
 
 			switch {
-			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
 			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
-				if _, err := os.Stat(fw.Filename); err != nil {
-					if ! os.IsNotExist(err) {
-						return
-					}
+				_, err = os.Stat(fw.Filename)
+				if err == nil {
+					continue
+				}
+				// With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
+				if !os.IsNotExist(err) {
+					return
 				}
 				fallthrough
 


### PR DESCRIPTION
This change fixes file truncation on Mac OS X (I have 10.11.6). The current code is broken there:
```
Vlads-MacBook-Air:tail vlad$ go test --test.run=TestReSeekInotify
2017/03/17 19:16:14 Stopping tail as file no longer exists: .test/reseek-inotify/test.txt
--- FAIL: TestReSeekInotify (0.20s)
	tail_test.go:499: tail ended early; expecting more: [h311o w0r1d endofworld]
FAIL
exit status 1
FAIL	github.com/hpcloud/tail	0.213s
```
The problems is that the file truncation operation apparently sends the `Chmod` event in Mac OS X, and the `ChangeEvents` function's `Chmod` case allows that event to [fall through](https://github.com/hpcloud/tail/blob/46ed7f0315f36b5f9b7c6ba82693362dc581d170/watch/inotify.go#L106) into the `Rename` case which removes the watch, preventing further updates.

This change discriminates between the case of non-existent file, which still falls through, and existing file, which causes the function to continue listening.