### PR TITLE
Fixes log reopening under inotify

### DIFF
--- a/tail_test.go
+++ b/tail_test.go
@@ -343,7 +343,7 @@ func reOpen(t *testing.T, poll bool) {
 		"test.txt",
 		Config{Follow: true, ReOpen: true, Poll: poll})
 	content := []string{"hello", "world", "more", "data", "endofworld"}
-	go tailTest.ReadLines(tail, content)
+	go tailTest.VerifyTailOutput(tail, content, false)
 
 	// deletion must trigger reopen
 	<-time.After(delay)
@@ -366,7 +366,7 @@ func reOpen(t *testing.T, poll bool) {
 	// Do not bother with stopping as it could kill the tomb during
 	// the reading of data written above. Timings can vary based on
 	// test environment.
-	tail.Cleanup()
+	tailTest.Cleanup(tail, false)
 }
 
 func reSeek(t *testing.T, poll bool) {

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -99,7 +99,7 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
 			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
 				if _, err := os.Stat(fw.Filename); err != nil {
-					if ! os.IsNotExist(err) {
+					if !os.IsNotExist(err) {
 						return
 					}
 				}

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -155,6 +155,8 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 
 	if shared.chans[winfo.fname] == nil {
 		shared.chans[winfo.fname] = make(chan fsnotify.Event)
+	}
+	if shared.done[winfo.fname] == nil {
 		shared.done[winfo.fname] = make(chan bool)
 	}
 

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -108,28 +108,10 @@ func remove(winfo *watchInfo) error {
 		delete(shared.done, winfo.fname)
 		close(done)
 	}
-
-	fname := winfo.fname
-	if winfo.isCreate() {
-		// Watch for new files to be created in the parent directory.
-		fname = filepath.Dir(fname)
-	}
-	shared.watchNums[fname]--
-	watchNum := shared.watchNums[fname]
-	if watchNum == 0 {
-		delete(shared.watchNums, fname)
-	}
 	shared.mux.Unlock()
 
-	// If we were the last ones to watch this file, unsubscribe from inotify.
-	// This needs to happen after releasing the lock because fsnotify waits
-	// synchronously for the kernel to acknowledge the removal of the watch
-	// for this file, which causes us to deadlock if we still held the lock.
-	if watchNum == 0 {
-		return shared.watcher.Remove(fname)
-	}
 	shared.remove <- winfo
-	return nil
+	return <-shared.error
 }
 
 // Events returns a channel to which FileEvents corresponding to the input filename
@@ -166,47 +148,48 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 		fname = filepath.Dir(fname)
 	}
 
+	var err error
 	// already in inotify watch
-	if shared.watchNums[fname] > 0 {
-		shared.watchNums[fname]++
-		if winfo.isCreate() {
-			shared.watchNums[winfo.fname]++
-		}
-		return nil
+	if shared.watchNums[fname] == 0 {
+		err = shared.watcher.Add(fname)
 	}
-
-	err := shared.watcher.Add(fname)
-	if err == nil {
-		shared.watchNums[fname]++
-		if winfo.isCreate() {
-			shared.watchNums[winfo.fname]++
-		}
-	}
+	shared.watchNums[fname]++
 	return err
 }
 
 // removeWatch calls fsnotify.RemoveWatch for the input filename and closes the
 // corresponding events channel.
-func (shared *InotifyTracker) removeWatch(winfo *watchInfo) {
+func (shared *InotifyTracker) removeWatch(winfo *watchInfo) error {
 	shared.mux.Lock()
-	defer shared.mux.Unlock()
 
 	ch := shared.chans[winfo.fname]
-	if ch == nil {
-		return
+	if ch != nil {
+		delete(shared.chans, winfo.fname)
+		close(ch)
 	}
 
-	delete(shared.chans, winfo.fname)
-	close(ch)
+	fname := winfo.fname
+	if winfo.isCreate() {
+		// Watch for new files to be created in the parent directory.
+		fname = filepath.Dir(fname)
+	}
+	shared.watchNums[fname]--
+	watchNum := shared.watchNums[fname]
+	if watchNum == 0 {
+		delete(shared.watchNums, fname)
+	}
+	shared.mux.Unlock()
 
-	if !winfo.isCreate() {
-		return
+	var err error
+	// If we were the last ones to watch this file, unsubscribe from inotify.
+	// This needs to happen after releasing the lock because fsnotify waits
+	// synchronously for the kernel to acknowledge the removal of the watch
+	// for this file, which causes us to deadlock if we still held the lock.
+	if watchNum == 0 {
+		err = shared.watcher.Remove(fname)
 	}
 
-	shared.watchNums[winfo.fname]--
-	if shared.watchNums[winfo.fname] == 0 {
-		delete(shared.watchNums, winfo.fname)
-	}
+	return err
 }
 
 // sendEvent sends the input event to the appropriate Tail.
@@ -241,7 +224,7 @@ func (shared *InotifyTracker) run() {
 			shared.error <- shared.addWatch(winfo)
 
 		case winfo := <-shared.remove:
-			shared.removeWatch(winfo)
+			shared.error <- shared.removeWatch(winfo)
 
 		case event, open := <-shared.watcher.Events:
 			if !open {

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -153,7 +153,9 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 	if shared.watchNums[fname] == 0 {
 		err = shared.watcher.Add(fname)
 	}
-	shared.watchNums[fname]++
+	if err == nil {
+		shared.watchNums[fname]++
+	}
 	return err
 }
 


### PR DESCRIPTION
TL;DR this fixes a bug in `fsnotify.Watch` reference counting resulting in `tail` stopping updates after a tailed file is moved when using inotify.

When `InotifyTracker.create` is called from `RemoveWatchCreate` it decrements the watch counter for the parent dir of the filename tracked, then removes the watch and bails out. But the corresponding `WatchCreate` was incrementing counters for both tracked filename and its parent. Thus, the count for the filename is leaked. The following `Create` call would find the count for the filename already at 1 and assume the watch for the filename itself is already there. Thus no watch would be created and no updates would be coming.


This change moves the cleanup code into the single place and makes sure each `InotifyTracker`'s `RemoveWatch` and `RemoveWatchCreate` calls correctly clean-up reference counts and watches created in corresponding `Watch` and `WatchCreate` calls. Also adds a couple of tests to verify the fix.