### PR TITLE
ensure the watcher has started before we read

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -250,6 +250,11 @@ func (tail *Tail) tailFileSync() {
 
 	tail.openReader()
 
+	if err := tail.watchChanges(); err != nil {
+		tail.Killf("Error watching for changes on %s: %s", tail.Filename, err)
+		return
+	}
+
 	var offset int64
 	var err error
 
@@ -331,19 +336,25 @@ func (tail *Tail) tailFileSync() {
 	}
 }
 
+// watchChanges ensures the watcher is running.
+func (tail *Tail) watchChanges() error {
+	if tail.changes != nil {
+		return nil
+	}
+	pos, err := tail.file.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return err
+	}
+	tail.changes, err = tail.watcher.ChangeEvents(&tail.Tomb, pos)
+	return err
+}
+
 // waitForChanges waits until the file has been appended, deleted,
 // moved or truncated. When moved or deleted - the file will be
 // reopened if ReOpen is true. Truncated files are always reopened.
 func (tail *Tail) waitForChanges() error {
-	if tail.changes == nil {
-		pos, err := tail.file.Seek(0, os.SEEK_CUR)
-		if err != nil {
-			return err
-		}
-		tail.changes, err = tail.watcher.ChangeEvents(&tail.Tomb, pos)
-		if err != nil {
-			return err
-		}
+	if err := tail.watchChanges(); err != nil {
+		return err
 	}
 
 	select {


### PR DESCRIPTION
...otherwise we can run into the scenario where: On start we read the contents of the file, we hit EOF, and start watching for changes. But in between the EOF and start watching, the file is updated. But since the watcher wasn't started, we don't notice.