### PR TITLE
remove unwanted log message

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -241,7 +241,7 @@ func (tail *Tail) tailFileSync() {
 	// Seek to requested location on first open of the file.
 	if tail.Location != nil {
 		_, err := tail.file.Seek(tail.Location.Offset, tail.Location.Whence)
-		tail.Logger.Printf("Seeked %s - %+v\n", tail.Filename, tail.Location)
+		//tail.Logger.Printf("Seeked %s - %+v\n", tail.Filename, tail.Location)
 		if err != nil {
 			tail.Killf("Seek error on %s: %s", tail.Filename, err)
 			return

--- a/tail.go
+++ b/tail.go
@@ -241,7 +241,6 @@ func (tail *Tail) tailFileSync() {
 	// Seek to requested location on first open of the file.
 	if tail.Location != nil {
 		_, err := tail.file.Seek(tail.Location.Offset, tail.Location.Whence)
-		//tail.Logger.Printf("Seeked %s - %+v\n", tail.Filename, tail.Location)
 		if err != nil {
 			tail.Killf("Seek error on %s: %s", tail.Filename, err)
 			return


### PR DESCRIPTION
When you have a nice program with a spinner watching a file, this print ruins the output.  In general, packages should avoid printing to console and instead return output so that the decision to display output can be made upstream.  For now, it would make sense to pull this message out.

Example: 

> 
> ⠋ Watching for fatal in api.log 2017/05/12 00:00:11 Seeked api.log - &{Offset:0 Whence:2}
> ⠙ Watching for fatal in api.log 