### PR TITLE
Solved the problem for never return the last line if it's not followed by a newline

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -224,8 +224,10 @@ func (tail *Tail) readLine() (string, error) {
 }
 
 func (tail *Tail) tailFileSync() {
-	defer tail.Done()
-	defer tail.close()
+	defer func() {
+		tail.close()
+		tail.Done()
+	}()
 
 	if !tail.MustExist {
 		// deferred first open.

--- a/tail.go
+++ b/tail.go
@@ -252,16 +252,12 @@ func (tail *Tail) tailFileSync() {
 
 	tail.openReader()
 
-	var offset int64
-	var err error
-
 	// Read line by line.
 	for {
 		// do not seek in named pipes
 		if !tail.Pipe {
 			// grab the position in case we need to back up in the event of a half-line
-			offset, err = tail.Tell()
-			if err != nil {
+			if _, err := tail.Tell(); err != nil {
 				tail.Kill(err)
 				return
 			}
@@ -297,10 +293,8 @@ func (tail *Tail) tailFileSync() {
 			}
 
 			if tail.Follow && line != "" {
-				// this has the potential to never return the last line if
-				// it's not followed by a newline; seems a fair trade here
-				err := tail.seekTo(SeekInfo{Offset: offset, Whence: 0})
-				if err != nil {
+				tail.sendLine(line)
+				if err := tail.seekEnd(); err != nil {
 					tail.Kill(err)
 					return
 				}


### PR DESCRIPTION
## What was the problem?
Even though enable the Follow mode, Could not get the last line if it is not newline on end of the line.

For example, I had read the file that is not followed by a newline on the last line using `github.com/hpcloud/tail`. like this.
```
host:192.168.12.34	user:-	time:2015-09-06T05:58:05+09:00	method:POST	uri:/foo/bar?token=xxx&uuid=1234	protocol:HTTP/1.1	status:200	size:12	api_status:-	request_time:0.247	apptime:0.057	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:41+09:00	method:POST	uri:/foo/bar?token=yyy	protocol:HTTP/1.1	status:200	size:34	api_status:-	request_time:0.012	apptime:0.100	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:42+09:00	method:GET	uri:/foo/bar?token=zzz	protocol:HTTP/1.1	status:200	size:56	api_status:-	request_time:0.034	apptime:0.123	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:44+09:00	method:POST	uri:/foo/bar?token=yyy	protocol:HTTP/1.1	status:200	size:34	api_status:-	request_time:0.123	apptime:0.234	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:44+09:00	method:POST	uri:/hoge/piyo?id=yyy	protocol:HTTP/1.1	status:200	size:34	api_status:-	request_time:0.123	apptime:0.234	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:05+09:00	method:POST	uri:/foo/bar?token=xxx&uuid=1234	protocol:HTTP/1.1	status:200	size:12	api_status:-	request_time:0.247	apptime:0.057	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:41+09:00	method:POST	uri:/foo/bar?token=yyy	protocol:HTTP/1.1	status:200	size:34	api_status:-	request_time:0.012	apptime:0.100	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:42+09:00	method:GET	uri:/foo/bar?token=zzz	protocol:HTTP/1.1	status:200	size:56	api_status:-	request_time:0.034	apptime:0.123	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/diary/entry/1234	protocol:HTTP/1.1	status:200	size:15	api_status:-	request_time:-	apptime:0.135	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/diary/entry/5678	protocol:HTTP/1.1	status:200	size:30	api_status:-	request_time:-	apptime:0.432	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:42+09:00	method:GET	uri:/foo/bar?token=zzz	protocol:HTTP/1.1	status:200	size:56	api_status:-	request_time:0.034	apptime:0.123	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/diary/entry/1234	protocol:HTTP/1.1	status:200	size:15	api_status:-	request_time:-	apptime:0.135	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/diary/entry/5678	protocol:HTTP/1.1	status:200	size:30	api_status:-	request_time:-	apptime:0.432	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:05+09:00	method:POST	uri:/foo/bar?token=xxx&uuid=1234	protocol:HTTP/1.1	status:200	size:12	api_status:-	request_time:0.247	apptime:0.057	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-  user_id:-
host:192.168.12.34	user:-	time:2015-09-06T05:58:41+09:00	method:POST	uri:/foo/bar?token=yyy	protocol:HTTP/1.1	status:200	size:34	api_status:-	request_time:0.012	apptime:0.100	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:42+09:00	method:GET	uri:/foo/bar?token=zzz	protocol:HTTP/1.1	status:200	size:56	api_status:-	request_time:0.034	apptime:0.123	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2	uuid:-	user_id:-
host:192.168.12.34	user:-	time:2015-09-06T06:00:43+09:00	method:GET	uri:/foo/bar	protocol:HTTP/1.1	status:400	size:15	api_status:-	request_time:-	apptime:-	upstream_addr:127.0.0.1:12345	referer:-	user_agent:curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.4 libidn/1.18 libssh2/1.4.3	uuid:-	user_id:-
```

But, when I use `tail -f`, I could get the the last line.
We must need to fix this problem.

Thank you.
