### PR TITLE
Fix fsnotify import path

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 	"gopkg.in/tomb.v1"
 )
 

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 type InotifyTracker struct {


### PR DESCRIPTION
The original go-fsnotify package was moved to "fsnotify/fsnotify", and so the import path has to be changed into the second form of the import alias. (described at http://labix.org/gopkg.in)