### PR TITLE
fixed import path of fsnotify

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 	"gopkg.in/tomb.v1"
 )
 

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hpcloud/tail/util"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 type InotifyTracker struct {


### PR DESCRIPTION
The correct import path for fsnotify is "gopkg.in/fsnotify/fsnotify.v1", rather than "gopkg.in/fsnotify.v1". See also https://gopkg.in/fsnotify.v1. Not sure if this was adjusted for fsnotify repo or why it did work earlier with the shorter path.