### PR TITLE
added line num to Line struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default:	test
 
 test:	*.go
-	go test -v -race ./...
+	go test -v -race -timeout 30s ./...
 
 fmt:
 	gofmt -w .

--- a/tail_test.go
+++ b/tail_test.go
@@ -106,6 +106,9 @@ func TestStopAtEOF(t *testing.T) {
 	if line.Text != "hello" {
 		t.Errorf("Expected to get 'hello', got '%s' instead", line.Text)
 	}
+	if line.Num != 1 {
+		t.Errorf("Expected to get 1, got %d instead", line.Num)
+	}
 
 	tailTest.VerifyTailOutput(tail, []string{"there", "world"}, false)
 	tail.StopAtEOF()
@@ -134,6 +137,7 @@ func TestOver4096ByteLine(t *testing.T) {
 	tailTest.RemoveFile("test.txt")
 	tailTest.Cleanup(tail, true)
 }
+
 func TestOver4096ByteLineWithSetMaxLineSize(t *testing.T) {
 	tailTest := NewTailTest("Over4096ByteLineMaxLineSize", t)
 	testString := strings.Repeat("a", 4097)
@@ -219,6 +223,40 @@ func TestReOpenPolling(t *testing.T) {
 	reOpen(t, true)
 }
 
+func TestReOpenWithCursor(t *testing.T) {
+	delay := 300 * time.Millisecond // account for POLL_DURATION
+	tailTest := NewTailTest("reopen-cursor", t)
+	tailTest.CreateFile("test.txt", "hello\nworld\n")
+	tail := tailTest.StartTail(
+		"test.txt",
+		Config{Follow: true, ReOpen: true, Poll: true})
+	content := []string{"hello", "world", "more", "data", "endofworld"}
+	go tailTest.VerifyTailOutputUsingCursor(tail, content, false)
+
+	// deletion must trigger reopen
+	<-time.After(delay)
+	tailTest.RemoveFile("test.txt")
+	<-time.After(delay)
+	tailTest.CreateFile("test.txt", "hello\nworld\nmore\ndata\n")
+
+	// rename must trigger reopen
+	<-time.After(delay)
+	tailTest.RenameFile("test.txt", "test.txt.rotated")
+	<-time.After(delay)
+	tailTest.CreateFile("test.txt", "hello\nworld\nmore\ndata\nendofworld\n")
+
+	// Delete after a reasonable delay, to give tail sufficient time
+	// to read all lines.
+	<-time.After(delay)
+	tailTest.RemoveFile("test.txt")
+	<-time.After(delay)
+
+	// Do not bother with stopping as it could kill the tomb during
+	// the reading of data written above. Timings can vary based on
+	// test environment.
+	tailTest.Cleanup(tail, false)
+}
+
 // The use of polling file watcher could affect file rotation
 // (detected via renames), so test these explicitly.
 
@@ -228,6 +266,31 @@ func TestReSeekInotify(t *testing.T) {
 
 func TestReSeekPolling(t *testing.T) {
 	reSeek(t, true)
+}
+
+func TestReSeekWithCursor(t *testing.T) {
+	tailTest := NewTailTest("reseek-cursor", t)
+	tailTest.CreateFile("test.txt", "a really long string goes here\nhello\nworld\n")
+	tail := tailTest.StartTail(
+		"test.txt",
+		Config{Follow: true, ReOpen: false, Poll: false})
+
+	go tailTest.VerifyTailOutputUsingCursor(tail, []string{
+		"a really long string goes here", "hello", "world", "but", "not", "me"}, false)
+
+	// truncate now
+	<-time.After(100 * time.Millisecond)
+	tailTest.TruncateFile("test.txt", "skip\nme\nplease\nbut\nnot\nme\n")
+
+	// Delete after a reasonable delay, to give tail sufficient time
+	// to read all lines.
+	<-time.After(100 * time.Millisecond)
+	tailTest.RemoveFile("test.txt")
+
+	// Do not bother with stopping as it could kill the tomb during
+	// the reading of data written above. Timings can vary based on
+	// test environment.
+	tailTest.Cleanup(tail, false)
 }
 
 func TestRateLimiting(t *testing.T) {
@@ -266,7 +329,10 @@ func TestTell(t *testing.T) {
 		Location: &SeekInfo{0, os.SEEK_SET}}
 	tail := tailTest.StartTail("test.txt", config)
 	// read noe line
-	<-tail.Lines
+	line := <-tail.Lines
+	if line.Num != 1 {
+		tailTest.Errorf("expected line to have number 1 but got %d", line.Num)
+	}
 	offset, err := tail.Tell()
 	if err != nil {
 		tailTest.Errorf("Tell return error: %s", err.Error())
@@ -284,6 +350,9 @@ func TestTell(t *testing.T) {
 		if l.Text != "world" && l.Text != "again" {
 			tailTest.Fatalf("mismatch; expected world or again, but got %s",
 				l.Text)
+		}
+		if l.Num < 1 || l.Num > 2 {
+			tailTest.Errorf("expected line number to be between 1 and 2 but got %d", l.Num)
 		}
 		break
 	}
@@ -518,7 +587,7 @@ func (t TailTest) StartTail(name string, config Config) *Tail {
 
 func (t TailTest) VerifyTailOutput(tail *Tail, lines []string, expectEOF bool) {
 	defer close(t.done)
-	t.ReadLines(tail, lines)
+	t.ReadLines(tail, lines, false)
 	// It is important to do this if only EOF is expected
 	// otherwise we could block on <-tail.Lines
 	if expectEOF {
@@ -529,27 +598,53 @@ func (t TailTest) VerifyTailOutput(tail *Tail, lines []string, expectEOF bool) {
 	}
 }
 
-func (t TailTest) ReadLines(tail *Tail, lines []string) {
-	for idx, line := range lines {
-		tailedLine, ok := <-tail.Lines
-		if !ok {
-			// tail.Lines is closed and empty.
-			err := tail.Err()
-			if err != nil {
-				t.Fatalf("tail ended with error: %v", err)
+func (t TailTest) VerifyTailOutputUsingCursor(tail *Tail, lines []string, expectEOF bool) {
+	defer close(t.done)
+	t.ReadLines(tail, lines, true)
+	// It is important to do this if only EOF is expected
+	// otherwise we could block on <-tail.Lines
+	if expectEOF {
+		line, ok := <-tail.Lines
+		if ok {
+			t.Fatalf("more content from tail: %+v", line)
+		}
+	}
+}
+
+func (t TailTest) ReadLines(tail *Tail, lines []string, useCursor bool) {
+	cursor := 1
+
+	for _, line := range lines {
+		for {
+			tailedLine, ok := <-tail.Lines
+			if !ok {
+				// tail.Lines is closed and empty.
+				err := tail.Err()
+				if err != nil {
+					t.Fatalf("tail ended with error: %v", err)
+				}
+				t.Fatalf("tail ended early; expecting more: %v", lines[cursor:])
 			}
-			t.Fatalf("tail ended early; expecting more: %v", lines[idx:])
-		}
-		if tailedLine == nil {
-			t.Fatalf("tail.Lines returned nil; not possible")
-		}
-		// Note: not checking .Err as the `lines` argument is designed
-		// to match error strings as well.
-		if tailedLine.Text != line {
-			t.Fatalf(
-				"unexpected line/err from tail: "+
-					"expecting <<%s>>>, but got <<<%s>>>",
-				line, tailedLine.Text)
+			if tailedLine == nil {
+				t.Fatalf("tail.Lines returned nil; not possible")
+			}
+
+			if useCursor && tailedLine.Num < cursor {
+				// skip lines up until cursor
+				continue
+			}
+
+			// Note: not checking .Err as the `lines` argument is designed
+			// to match error strings as well.
+			if tailedLine.Text != line {
+				t.Fatalf(
+					"unexpected line/err from tail: "+
+						"expecting <<%s>>>, but got <<<%s>>>",
+					line, tailedLine.Text)
+			}
+
+			cursor++
+			break
 		}
 	}
 }


### PR DESCRIPTION
I made this change because it's generally useful to know the line number from the file being tailed. One particular case it's useful for is when the process writing to the file truncates and rewrites the entire file each time there's new content. By keeping the number of the last processed line, we can use it as a cursor to skip past lines that are sent on the Lines chan again after a re-open.

I've added a couple unit tests for it:
TestReOpenWithCursor
TestReSeekWithCursor