### PR TITLE
Don’t block on write if we’ve been killed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,16 @@
-# API v1 (gopkg.in/hpcloud/tail.v1)
+# API v1 (gopkg.in/paulsc/tail.v1)
 
 ## April, 2016
 
 * Migrated to godep, as depman is not longer supported
 * Introduced golang vendoring feature
-* Fixed issue [#57](https://github.com/hpcloud/tail/issues/57) related to reopen deleted file 
+* Fixed issue [#57](https://github.com/paulsc/tail/issues/57) related to reopen deleted file 
 
 ## July, 2015
 
 * Fix inotify watcher leak; remove `Cleanup` (#51)
 
-# API v0 (gopkg.in/hpcloud/tail.v0)
+# API v0 (gopkg.in/paulsc/tail.v0)
 
 ## June, 2015
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM golang
 
-RUN mkdir -p $GOPATH/src/github.com/hpcloud/tail/
-ADD . $GOPATH/src/github.com/hpcloud/tail/
+RUN mkdir -p $GOPATH/src/github.com/paulsc/tail/
+ADD . $GOPATH/src/github.com/paulsc/tail/
 
 # expecting to fetch dependencies successfully.
-RUN go get -v github.com/hpcloud/tail
+RUN go get -v github.com/paulsc/tail
 
 # expecting to run the test successfully.
-RUN go test -v github.com/hpcloud/tail
+RUN go test -v github.com/paulsc/tail
 
 # expecting to install successfully
-RUN go install -v github.com/hpcloud/tail
-RUN go install -v github.com/hpcloud/tail/cmd/gotail
+RUN go install -v github.com/paulsc/tail
+RUN go install -v github.com/paulsc/tail/cmd/gotail
 
 RUN $GOPATH/bin/gotail -h || true
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/hpcloud/tail",
+	"ImportPath": "github.com/paulsc/tail",
 	"GoVersion": "go1.5.1",
 	"Deps": [
 		{

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ fmt:
 
 # Run the test in an isolated environment.
 fulltest:
-	docker build -t hpcloud/tail .
+	docker build -t paulsc/tail .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Build Status](https://travis-ci.org/hpcloud/tail.svg)](https://travis-ci.org/hpcloud/tail)
-[![Build status](https://ci.appveyor.com/api/projects/status/vrl3paf9md0a7bgk/branch/master?svg=true)](https://ci.appveyor.com/project/Nino-K/tail/branch/master)
+# Paul's fork
+
+Also check https://github.com/hpcloud/tail
+Also check https://github.com/nxadm/tail
 
 # Go package for tail-ing files
 
@@ -12,7 +14,7 @@ for line := range t.Lines {
 }
 ```
 
-See [API documentation](http://godoc.org/github.com/hpcloud/tail).
+See [API documentation](http://godoc.org/github.com/paulsc/tail).
 
 ## Log rotation
 
@@ -21,8 +23,8 @@ designed to work with log rotation tools.
 
 ## Installing
 
-    go get github.com/hpcloud/tail/...
+    go get github.com/paulsc/tail/...
 
 ## Windows support
 
-This package [needs assistance](https://github.com/hpcloud/tail/labels/Windows) for full Windows support.
+This package [needs assistance](https://github.com/paulsc/tail/labels/Windows) for full Windows support.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ build_script:
 - SET GOPATH=c:\workspace
 - go test -v -race ./...
 test: off
-clone_folder: c:\workspace\src\github.com\hpcloud\tail
+clone_folder: c:\workspace\src\github.com\paulsc\tail
 branches:
   only:
   - master

--- a/cmd/gotail/gotail.go
+++ b/cmd/gotail/gotail.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hpcloud/tail"
+	"github.com/paulsc/tail"
 )
 
 func args2config() (tail.Config, int64) {

--- a/tail.go
+++ b/tail.go
@@ -414,7 +414,11 @@ func (tail *Tail) sendLine(line string) bool {
 	}
 
 	for _, line := range lines {
-		tail.Lines <- &Line{line, now, nil}
+		select {
+		case tail.Lines <- &Line{line, now, nil}:
+		case <-tail.Dying():
+			return true
+		}
 	}
 
 	if tail.Config.RateLimiter != nil {

--- a/tail.go
+++ b/tail.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/util"
-	"github.com/hpcloud/tail/watch"
+	"github.com/paulsc/tail/ratelimiter"
+	"github.com/paulsc/tail/util"
+	"github.com/paulsc/tail/watch"
 	"gopkg.in/tomb.v1"
 )
 

--- a/tail_test.go
+++ b/tail_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/watch"
+	"github.com/paulsc/tail/ratelimiter"
+	"github.com/paulsc/tail/watch"
 )
 
 func init() {

--- a/tail_windows.go
+++ b/tail_windows.go
@@ -3,7 +3,7 @@
 package tail
 
 import (
-	"github.com/hpcloud/tail/winfile"
+	"github.com/paulsc/tail/winfile"
 	"os"
 )
 

--- a/util/util.go
+++ b/util/util.go
@@ -18,7 +18,7 @@ var LOGGER = &Logger{log.New(os.Stderr, "", log.LstdFlags)}
 
 // fatal is like panic except it displays only the current goroutine's stack.
 func Fatal(format string, v ...interface{}) {
-	// https://github.com/hpcloud/log/blob/master/log.go#L45
+	// https://github.com/paulsc/log/blob/master/log.go#L45
 	LOGGER.Output(2, fmt.Sprintf("FATAL -- "+format, v...)+"\n"+string(debug.Stack()))
 	os.Exit(1)
 }

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/paulsc/tail/util"
 
 	"gopkg.in/fsnotify/fsnotify.v1"
 	"gopkg.in/tomb.v1"

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/paulsc/tail/util"
 
 	"gopkg.in/fsnotify/fsnotify.v1"
 )

--- a/watch/polling.go
+++ b/watch/polling.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/paulsc/tail/util"
 	"gopkg.in/tomb.v1"
 )
 


### PR DESCRIPTION
Hi - I've been debugging this issue and fixed it with the changes in this pull request. I'm a bit new to go - so forgive me If I misunderstand, but here's what happened. 

Quick context first: I am using hpcloud/tail in [my component](https://gist.github.com/paulsc/15feacd2b4f53b3310fb02109b636c55), called "CsvTail" which tails a file, parses the CSV records in that file, and only stops when it encounters the NUL byte at the beginning of a line. The CSV files are streamed and written by another service, which uses the NUL byte to indicate the end of the file.

The code would sometimes deadlock when calling [tail.Stop()](https://gist.github.com/paulsc/15feacd2b4f53b3310fb02109b636c55#file-csvtail-go-L80). Stop() internally calls tail.Wait(), which waits for the tomb to be declared as dead. 

What happens is that another line comes in after [my read of the NUL byte](https://gist.github.com/paulsc/15feacd2b4f53b3310fb02109b636c55#file-csvtail-go-L46), but before [my Stop() call](https://gist.github.com/paulsc/15feacd2b4f53b3310fb02109b636c55#file-csvtail-go-L55), causing the tail library to block on [this line](https://github.com/hpcloud/tail/blob/a1dbeea552b7c8df4b542c66073e393de198a800/tail.go#L417). 

Tail would never reach the end of tailFileSync() where it checks for tail.Dying(), returns, and sets the tomb as Done().

My fix is to add a select and "cancel" the write if the tomb enters dying state. 

Not sure if this is right though let me know if I'm misunderstanding or misusing the library.

Best,

Paul



