### PR TITLE
Enable illumos support and other posix unixes

### DIFF
--- a/tail_posix.go
+++ b/tail_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
+// +build !windows
 
 package tail
 


### PR DESCRIPTION
Wrong use of build tags prevents building on platforms that are post but not explicitly listed like illumos.