### PR TITLE
Fixup build tags

### DIFF
--- a/tail_posix.go
+++ b/tail_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
+// +build !windows
 
 package tail
 


### PR DESCRIPTION
This sets up the build tags to correctly use os.OpenFile on all posix Oses