### PR TITLE
Add illumos to build constraints

### DIFF
--- a/tail_posix.go
+++ b/tail_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
+// +build linux darwin freebsd netbsd openbsd illumos
 
 package tail
 


### PR DESCRIPTION
Please consider this change, which makes it possible to build this package on Illumos. Here's an example without and with this change.

Without:
```
$ go get github.com/hpcloud/tail
# github.com/hpcloud/tail
go/pkg/mod/github.com/hpcloud/tail@v1.0.0/tail.go:127:17: undefined: OpenFile
go/pkg/mod/github.com/hpcloud/tail@v1.0.0/tail.go:191:20: undefined: OpenFile
```

With:
```
omni@vm-omnios-1:~$ go get github.com/szaydel/tail@3acc3e6bb346dafeacbc2dcc3a2b748b0d27f1bb
omni@vm-omnios-1:~$ echo $?
0
```

Thank you!